### PR TITLE
Rebuilds when build system arguments or artifact patterns change

### DIFF
--- a/application.go
+++ b/application.go
@@ -50,7 +50,11 @@ func NewApplication(applicationPath string, arguments []string, artifactResolver
 	if err != nil {
 		return Application{}, fmt.Errorf("unable to create file listing for %s\n%w", applicationPath, err)
 	}
-	expected := map[string][]sherpa.FileEntry{"files": l}
+	expected := map[string]interface{}{
+		"files": l,
+		"arguments": arguments,
+		"artifact-pattern": artifactResolver.Pattern(),
+	}
 
 	return Application{
 		ApplicationPath:  applicationPath,

--- a/resolvers.go
+++ b/resolvers.go
@@ -112,14 +112,21 @@ type ArtifactResolver struct {
 	InterestingFileDetector InterestingFileDetector
 }
 
+// Pattern returns the glob that ArtifactResolver will use for resolution.
+func (a *ArtifactResolver) Pattern() string {
+	pattern, ok := a.ConfigurationResolver.Resolve(a.ArtifactConfigurationKey)
+	if ok {
+		return pattern
+	}
+	if module, ok := a.ConfigurationResolver.Resolve(a.ModuleConfigurationKey); ok {
+		return filepath.Join(module, pattern)
+	}
+	return pattern
+}
+
 // Resolve resolves the artifact that was created by the build system.
 func (a *ArtifactResolver) Resolve(applicationPath string) (string, error) {
-	pattern, ok := a.ConfigurationResolver.Resolve(a.ArtifactConfigurationKey)
-	if !ok {
-		if s, ok := a.ConfigurationResolver.Resolve(a.ModuleConfigurationKey); ok {
-			pattern = filepath.Join(s, pattern)
-		}
-	}
+	pattern := a.Pattern()
 
 	file := filepath.Join(applicationPath, pattern)
 	candidates, err := filepath.Glob(file)


### PR DESCRIPTION
Even if the source files are identical between builds, a change to the build
configuration can produce different build results. Therefore we must
rebuild the application when certain configuration changes.

This solves for cases common to all build system implementations.

Rebuilds on:
1. changes to build arguments
2. changes to artifact patterns resolved from configured artifact path or module

Still missing:
1. provide mechanism for build system implementation specific cache invalidation (e.g.
hash of maven settings.xml)

Signed-off-by: Emily Casey <ecasey@pivotal.io>