### PR TITLE
Enable ArtifactResolver to provide additional help instructions if it cannot find an artifact

### DIFF
--- a/resolvers.go
+++ b/resolvers.go
@@ -111,6 +111,9 @@ type ArtifactResolver struct {
 
 	// InterestingFileDetector is used to determine if a file is a candidate for artifact resolution.
 	InterestingFileDetector InterestingFileDetector
+
+	// AdditionalHelpMessage can be used to supply context specific instructions if no matching artifact is found
+	AdditionalHelpMessage string
 }
 
 // Pattern returns the glob that ArtifactResolver will use for resolution.
@@ -153,7 +156,11 @@ func (a *ArtifactResolver) Resolve(applicationPath string) (string, error) {
 	}
 
 	sort.Strings(artifacts)
-	return "", fmt.Errorf("unable to find single built artifact in %s, candidates: %s", pattern, candidates)
+	helpMsg := fmt.Sprintf("unable to find single built artifact in %s, candidates: %s", pattern, candidates)
+	if len(a.AdditionalHelpMessage) > 0 {
+		helpMsg = fmt.Sprintf("%s. %s", helpMsg, a.AdditionalHelpMessage)
+	}
+	return "", fmt.Errorf(helpMsg)
 }
 
 // ResolveArguments resolves the arguments that should be passed to a build system.

--- a/resolvers_test.go
+++ b/resolvers_test.go
@@ -123,6 +123,19 @@ func testResolvers(t *testing.T, context spec.G, it spec.S) {
 				filepath.Join(path, "test-file-1"), filepath.Join(path, "test-file-2"))))
 		})
 
+		it("fails with multiple candidates and provides extra help", func() {
+			Expect(ioutil.WriteFile(filepath.Join(path, "test-file-1"), []byte{}, 0644)).To(Succeed())
+			Expect(ioutil.WriteFile(filepath.Join(path, "test-file-2"), []byte{}, 0644)).To(Succeed())
+			detector.On("Interesting", mock.Anything).Return(true, nil)
+
+			resolver.AdditionalHelpMessage = "Some more help."
+
+			_, err := resolver.Resolve(path)
+
+			Expect(err).To(MatchError(fmt.Sprintf("unable to find single built artifact in test-*, candidates: [%s %s]. Some more help.",
+				filepath.Join(path, "test-file-1"), filepath.Join(path, "test-file-2"))))
+		})
+
 		context("$TEST_ARTIFACT_CONFIGURATION_KEY", func() {
 			it.Before(func() {
 				Expect(os.Setenv("TEST_ARTIFACT_CONFIGURATION_KEY", "another-file")).To(Succeed())


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

ArtifactResolver prints a generic error message, but individual build systems can provide more specific instructions on what a user should do if the artifact cannot be found.

## Use Cases
<!-- An explanation of the use cases your change enables -->
See conversation here https://github.com/paketo-buildpacks/gradle/issues/54#issuecomment-819520457

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
