### PR TITLE
Clean up log output

### DIFF
--- a/application.go
+++ b/application.go
@@ -63,6 +63,10 @@ func (a Application) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 			return libcnb.Layer{}, fmt.Errorf("error running build\n%w", err)
 		}
 
+		// In some cases, process output does not end with a clean line of output
+		// This resets the cursor to the beginningo of the next line so indentation lines up
+		a.Logger.Info()
+
 		// Persist Artifacts
 		artifacts, err := a.ArtifactResolver.ResolveMany(a.ApplicationPath)
 		if err != nil {
@@ -144,6 +148,7 @@ func (a Application) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 	// Restore compiled artifacts
 	file := filepath.Join(layer.Path, "application.zip")
 	if _, err := os.Stat(file); err == nil {
+		a.Logger.Header("Restoring application artifact")
 		in, err := os.Open(file)
 		if err != nil {
 			return libcnb.Layer{}, fmt.Errorf("unable to open %s\n%w", file, err)
@@ -154,7 +159,7 @@ func (a Application) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 			return libcnb.Layer{}, fmt.Errorf("unable to extract %s\n%w", file, err)
 		}
 	} else if err != nil && os.IsNotExist(err) {
-		a.Logger.Infof("Restoring multiple artifacts")
+		a.Logger.Header("Restoring multiple artifacts")
 		err := copyDirectory(layer.Path, a.ApplicationPath)
 		if err != nil {
 			return libcnb.Layer{}, fmt.Errorf("unable to restore multiple artifacts\n%w", err)


### PR DESCRIPTION
## Summary

Log clean up.

## Use Cases

- Adds a line break after running the build tool. This cleans up the output which can sometimes end mid-line. Resetting to the next line prevents the next output from the buildpack from being in the wrong place.
- Changes the log level to use header & add a symmetric log entry for the single artifact restore path

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
