### PR TITLE
Generate label-based BOM for all API versions

### DIFF
--- a/application.go
+++ b/application.go
@@ -44,7 +44,6 @@ type Application struct {
 	Logger           bard.Logger
 	BOM              *libcnb.BOM
 	SBOMScanner      sbom.SBOMScanner
-	BuildpackAPI     string
 }
 
 func (a Application) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
@@ -123,14 +122,12 @@ func (a Application) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 		return libcnb.Layer{}, fmt.Errorf("unable to create Build SBoM \n%w", err)
 	}
 
-	if a.BuildpackAPI == "0.6" || a.BuildpackAPI == "0.5" || a.BuildpackAPI == "0.4" || a.BuildpackAPI == "0.3" || a.BuildpackAPI == "0.2" || a.BuildpackAPI == "0.1" {
-		entry, err := a.Cache.AsBOMEntry()
-		if err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to generate build dependencies\n%w", err)
-		}
-		entry.Metadata["layer"] = a.Cache.Name()
-		a.BOM.Entries = append(a.BOM.Entries, entry)
+	entry, err := a.Cache.AsBOMEntry()
+	if err != nil {
+		return libcnb.Layer{}, fmt.Errorf("unable to generate build dependencies\n%w", err)
 	}
+	entry.Metadata["layer"] = a.Cache.Name()
+	a.BOM.Entries = append(a.BOM.Entries, entry)
 
 	// Purge Workspace
 	a.Logger.Header("Removing source code")

--- a/factory.go
+++ b/factory.go
@@ -37,7 +37,6 @@ func (f *ApplicationFactory) NewApplication(
 	bom *libcnb.BOM,
 	applicationPath string,
 	bomScanner sbom.SBOMScanner,
-	buildpackAPI string,
 ) (Application, error) {
 
 	app := Application{
@@ -49,7 +48,6 @@ func (f *ApplicationFactory) NewApplication(
 		Executor:         f.Executor,
 		BOM:              bom,
 		SBOMScanner:      bomScanner,
-		BuildpackAPI:     buildpackAPI,
 	}
 
 	expected, err := f.expectedMetadata(additionalMetadata, app)

--- a/factory_test.go
+++ b/factory_test.go
@@ -86,7 +86,6 @@ func testFactory(t *testing.T, context spec.G, it spec.S) {
 				},
 			}
 			bomScanner := sbom.NewSyftCLISBOMScanner(libcnb.Layers{}, executor, bard.Logger{})
-			buildpackAPI := "0.7"
 
 			application, err = applicationFactory.NewApplication(
 				map[string]interface{}{"addl-key": "addl-value"},
@@ -97,7 +96,6 @@ func testFactory(t *testing.T, context spec.G, it spec.S) {
 				nil,
 				appDir,
 				bomScanner,
-				buildpackAPI,
 			)
 			Expect(err).NotTo(HaveOccurred())
 		})


### PR DESCRIPTION
## Summary

Starting with lifecycle 0.13.3, it is permitted to have both the old style label-based BOM information and the new style layer-based BOM information. If the buildpack API is 0.6 or older, label-based BOMs only is OK. If the buildpack API is 0.7, you may have both label-based BOM and layer-based BOM or just layer-based BOM. It is permitted to have just label-based BOM, however, that will generate a warning from the lifecycle.

The libpak library was adjusted to support this. This change updates to remove unnecessary if checks, unnecessarily passing the buildpack API and updates tests to pass.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
