### PR TITLE
Skip generation of label-base BOM

### DIFF
--- a/application.go
+++ b/application.go
@@ -122,12 +122,14 @@ func (a Application) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 		return libcnb.Layer{}, fmt.Errorf("unable to create Build SBoM \n%w", err)
 	}
 
-	entry, err := a.Cache.AsBOMEntry()
-	if err != nil {
-		return libcnb.Layer{}, fmt.Errorf("unable to generate build dependencies\n%w", err)
+	if !sherpa.ResolveBool("BP_BOM_LABEL_DISABLED") {
+		entry, err := a.Cache.AsBOMEntry()
+		if err != nil {
+			return libcnb.Layer{}, fmt.Errorf("unable to generate build dependencies\n%w", err)
+		}
+		entry.Metadata["layer"] = a.Cache.Name()
+		a.BOM.Entries = append(a.BOM.Entries, entry)
 	}
-	entry.Metadata["layer"] = a.Cache.Name()
-	a.BOM.Entries = append(a.BOM.Entries, entry)
 
 	// Purge Workspace
 	a.Logger.Header("Removing source code")

--- a/application_test.go
+++ b/application_test.go
@@ -153,7 +153,7 @@ func testApplication(t *testing.T, context spec.G, it spec.S) {
 		}))
 	})
 
-	context("label-based BOM is surpressed", func() {
+	context("label-based BOM is suppressed", func() {
 		it.Before(func() {
 			Expect(os.Setenv("BP_BOM_LABEL_DISABLED", "true")).To(Succeed())
 		})


### PR DESCRIPTION
## Summary

When `$BP_BOM_LABEL_DISABLED=true`, libpak will throw away label-based BOM information. This PR also looks at that env variable and will skip what is an expensive operation, i.e. fetching all the metadata from the build tool. By default, the label-based BOM is generated so this does not impact that scenario. If specifically disabled, then this will make the build faster.

## Use Cases

If you don't want the label-based BOM, then you shouldn't have to wait for it to generate. This PR makes builds faster. It can also work around some bugs. For example, if you map in your Maven directory from your local machine this can cause failures or make things really slow.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
